### PR TITLE
Added var keyword to onMove and onDie functions

### DIFF
--- a/js/MonsterTV.js
+++ b/js/MonsterTV.js
@@ -60,7 +60,7 @@ define(['EventEmitter', 'GameCanvas', 'Messages'],
   };
 
 
-  onMove = function(event) {
+  var onMove = function(event) {
     var min = this.canvas.getTileOrigin();
     var max = this.canvas.getMaxTile();
 
@@ -69,7 +69,7 @@ define(['EventEmitter', 'GameCanvas', 'Messages'],
   };
 
 
-  onDie = function(event) {
+  var onDie = function(event) {
     this._tracking.removeEventListener(Messages.SPRITE_MOVE, this._onMove);
     this._tracking.removeEventListener(Messages.SPRITE_DYING, this._onDie);
     this._tracking = null;


### PR DESCRIPTION
Was throwing error when running from source in IE11 because onMove was "not defined" because the class is using strict mode.
