### PR TITLE
added A 'return' to growZone method

### DIFF
--- a/js/BlockMapUtils.js
+++ b/js/BlockMapUtils.js
@@ -265,6 +265,8 @@ define(['BlockMap', 'Commercial', 'Industrial', 'MiscUtils', 'Random', 'Resident
       census.landValueAverage = Math.floor(totalLandValue / developedTileCount);
     else
       census.landValueAverage = 0;
+      
+    // console.log('lValue: ' + census.landValueAverage)
 
     // Smooth the pollution map twice
     smoothMap(tempMap1, tempMap2, SMOOTH_ALL_THEN_CLAMP);
@@ -415,6 +417,8 @@ define(['BlockMap', 'Commercial', 'Industrial', 'MiscUtils', 'Random', 'Resident
     var xTot = 0;
     var yTot = 0;
     var zoneTotal = 0;
+      
+      tempMap1.clear();
 
     for (var x = 0, width = map.width; x < width; x++) {
       for (var y = 0, height = map.height; y < height; y++) {
@@ -433,7 +437,7 @@ define(['BlockMap', 'Commercial', 'Industrial', 'MiscUtils', 'Random', 'Resident
           yTot += y;
           zoneTotal++;
         } else {
-          tempMap1.worldSet(x, y, 0);
+          // tempMap1.worldSet(x, y, 0);
         }
       }
     }

--- a/js/Residential.js
+++ b/js/Residential.js
@@ -129,6 +129,7 @@ define(['Config', 'Random', 'Tile', 'TileUtils', 'Traffic', 'ZoneUtils'],
         ZoneUtils.incRateOfGrowth(blockMaps, x, y, 8);
         return;
       }
+        return;
     }
 
     if (population < 40) {


### PR DESCRIPTION
I found a bug which a residential zone was getting bigger without any effort. R-Zones need high population density to be promoted from 'FREEZ' tile.

At line 126 in Residential.js, the conditional statement checks if the residential zone meet the requirement to grow population. and the program should be escaped growZone method when one is failed the population density check.

previous version keep going to the next conditional statement, so the R-Zones can keep growing its population with low density.