### PR TITLE
Fix placing railroad tiles

### DIFF
--- a/src/railTool.js
+++ b/src/railTool.js
@@ -25,7 +25,7 @@ RailTool.prototype.layRail = function(x, y) {
 
   switch (tile) {
     case TileValues.DIRT:
-      this._worldEffects.setTile(x, y, TileValues.LHRAIL | BULLBIT | BURNBIT);
+      this._worldEffects.setTile(x, y, TileValues.LHRAIL, BULLBIT | BURNBIT);
       break;
 
     case TileValues.RIVER:


### PR DESCRIPTION
I wasn't able to properly test this locally because I couldn't install dependencies. Which Node.js version do you use for this?

However, I tested this by modifying the minified JS directly on my fork, and confirmed that this fixes placing railroad tiles.

Fixes #35.